### PR TITLE
Allow preflight requests to the API.

### DIFF
--- a/extensions/api/script.py
+++ b/extensions/api/script.py
@@ -7,6 +7,9 @@ from modules.text_generation import encode, generate_reply
 
 params = {
     'port': 5000,
+    'allowed-origins': [
+        '*'
+    ]
 }
 
 
@@ -14,6 +17,8 @@ class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
         if self.path == '/api/v1/model':
             self.send_response(200)
+            self.send_header('Access-Control-Allow-Origin', ', '.join(params['allowed-origins']))
+            self.send_header('Access-Control-Allow-Methods', 'GET')
             self.end_headers()
             response = json.dumps({
                 'result': shared.model_name
@@ -30,6 +35,8 @@ class Handler(BaseHTTPRequestHandler):
         if self.path == '/api/v1/generate':
             self.send_response(200)
             self.send_header('Content-Type', 'application/json')
+            self.send_header('Access-Control-Allow-Origin', ', '.join(params['allowed-origins']))
+            self.send_header('Access-Control-Allow-Methods', 'POST')
             self.end_headers()
 
             prompt = body['prompt']
@@ -86,6 +93,8 @@ class Handler(BaseHTTPRequestHandler):
             # Not compatible with KoboldAI api
             self.send_response(200)
             self.send_header('Content-Type', 'application/json')
+            self.send_header('Access-Control-Allow-Origin', ', '.join(params['allowed-origins']))
+            self.send_header('Access-Control-Allow-Methods', 'POST')
             self.end_headers()
 
             tokens = encode(body['prompt'])[0]

--- a/extensions/api/script.py
+++ b/extensions/api/script.py
@@ -14,6 +14,17 @@ params = {
 
 
 class Handler(BaseHTTPRequestHandler):
+    def do_OPTIONS(self):
+        self.send_response(200)
+        self.send_header('Access-Control-Allow-Origin', ', '.join(params['allowed-origins']))
+        self.send_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+        self.send_header('Access-Control-Allow-Headers', 'Content-Type')
+        self.send_header('Access-Control-Max-Age', '86400')
+        self.end_headers()
+        response = json.dumps({})
+
+        self.wfile.write(response.encode('utf-8'))
+
     def do_GET(self):
         if self.path == '/api/v1/model':
             self.send_response(200)


### PR DESCRIPTION
Most browsers will make a preflight request to the API before making the actual `GET`/`POST`/etc request. This PR adds support for that functionality by handling the `OPTIONS` request method.

A configurable list of allowed origins has also been added to the API script's `params` dictionary. By default, this list contains `*` to allow requests from all origins:
```python
params = {
    'port': 5000,
    'allowed-origins': [
        '*'
    ]
}
```